### PR TITLE
use one context for multilple generative plugins. And, add some READM…

### DIFF
--- a/model_plugin/generative_model/kerneldensity/src/main/scala/org/graphicalmodellab/model/generative/kerneldensity/TestByCrossValidation.scala
+++ b/model_plugin/generative_model/kerneldensity/src/main/scala/org/graphicalmodellab/model/generative/kerneldensity/TestByCrossValidation.scala
@@ -14,7 +14,7 @@
   * limitations under the License.
   */
 
-package org.graphicalmodellab.model
+package org.graphicalmodellab.model.generative.kerneldensity
 
 import com.typesafe.config.Config
 import org.apache.log4j.LogManager

--- a/model_plugin/generative_model/kerneldensity/src/main/scala/org/graphicalmodellab/model/generative/kerneldensity/package.scala
+++ b/model_plugin/generative_model/kerneldensity/src/main/scala/org/graphicalmodellab/model/generative/kerneldensity/package.scala
@@ -14,12 +14,12 @@
   * limitations under the License.
   */
 
-package org.graphicalmodellab
+package org.graphicalmodellab.model.generative
 
 import org.graphicalmodellab.api.graph_api._
 import play.api.libs.json.{JsSuccess, Reads}
 
-package object model {
+package object kerneldensity {
   case class request(datasource: String, targetLabel: String, numOfSplit: Int, graph: graph)
   implicit lazy val requestReads: Reads[request] = Reads[request] {
     json => JsSuccess(request(

--- a/model_plugin/generative_model/multivariateguassian/src/main/scala/org/graphicalmodellab/model/generative/multivariateguassian/TestByCrossValidation.scala
+++ b/model_plugin/generative_model/multivariateguassian/src/main/scala/org/graphicalmodellab/model/generative/multivariateguassian/TestByCrossValidation.scala
@@ -14,7 +14,7 @@
   * limitations under the License.
   */
 
-package org.graphicalmodellab.model
+package org.graphicalmodellab.model.generative.multivariateguassian
 
 import org.apache.log4j.LogManager
 import org.apache.spark.mllib.linalg.{Matrix, Vectors}

--- a/model_plugin/generative_model/multivariateguassian/src/main/scala/org/graphicalmodellab/model/generative/multivariateguassian/package.scala
+++ b/model_plugin/generative_model/multivariateguassian/src/main/scala/org/graphicalmodellab/model/generative/multivariateguassian/package.scala
@@ -14,12 +14,12 @@
   * limitations under the License.
   */
 
-package org.graphicalmodellab
+package org.graphicalmodellab.model.generative
 
 import org.graphicalmodellab.api.graph_api._
 import play.api.libs.json.{JsSuccess, Reads}
 
-package object model {
+package object multivariateguassian {
   case class request(datasource: String, targetLabel: String, numOfSplit: Int,graph: graph)
   implicit lazy val requestReads: Reads[request] = Reads[request] {
     json => JsSuccess(request(

--- a/model_plugin/generative_plugin/README.md
+++ b/model_plugin/generative_plugin/README.md
@@ -14,6 +14,24 @@ sbt
 
 "-Dspray.can.parsing.max-content-length=20m" option is for increasing the jar file size limit.
 
+## Other Configuration
+
+### max-jobs-per-context = 16
+Depending on the environment, your spark job server might be able to launch one application per one context at a time.
+
+So, if you want to run multiple application on the same context parallelly, then setup this configuration.
+
+### context-per-jvm = false
+It sounds that in dev mode, we cannot set this option to be true.
+
+## Note:
+This plugins have been tested only in dev mode. I have not tried them in production environment.
+
+Also, I have not been able to run multiple applications in different context concurrently.
+I think this is related to one option, context-per-jvm = false.
+
+It sounds that this option cannot be set true in dev mode.
+
 # How to Develop/Deploy Plugin for Graph Calculation Model
 GML uses ServiceLoader (Java library) to load your plugin into GML service.
 

--- a/model_plugin/generative_plugin/kernel_density_algorithm_plugin/src/main/scala/org/graphicalmodellab/plugin/ModelKernelDensityCSV.scala
+++ b/model_plugin/generative_plugin/kernel_density_algorithm_plugin/src/main/scala/org/graphicalmodellab/plugin/ModelKernelDensityCSV.scala
@@ -61,10 +61,10 @@ class ModelKernelDensityCSV extends Model{
 
   var gmlDBClient: GmlDBAPIClient = null;
   // Three Parameters for spark-job-server
-  val contextName = "model_kernel_density_context"
+  val contextName = "generative_plugin_context"
   val appNameSparkJob = "model_kernel_density_app"
   val appJar = config.getString("app.jar")
-  val classPath = "org.graphicalmodellab.model.TestByCrossValidation"
+  val classPath = "org.graphicalmodellab.model.generative.kerneldensity.TestByCrossValidation"
   val sparkJobServerHost = config.getString("spark.job.server.host")
 
   override def getModelName: String = "KernelDensity"

--- a/model_plugin/generative_plugin/multivariate_guassian_algorithm_plugin/src/main/scala/org/graphicalmodellab/plugin/ModelMultivariateGuassianCSV.scala
+++ b/model_plugin/generative_plugin/multivariate_guassian_algorithm_plugin/src/main/scala/org/graphicalmodellab/plugin/ModelMultivariateGuassianCSV.scala
@@ -64,10 +64,10 @@ class ModelMultivariateGuassianCSV extends Model{
   val config = ConfigFactory.load("model_multivariate_guassian.conf")
 
   // Three Parameters for spark-job-server
-  val contextName = "model_multivariate_guassian_context"
+  val contextName = "generative_plugin_context"
   val appNameSparkJob = "model_multivariate_guassian_app"
   val appJar = config.getString("app.jar")
-  val classPath = "org.graphicalmodellab.model.TestByCrossValidation"
+  val classPath = "org.graphicalmodellab.model.generative.multivariateguassian.TestByCrossValidation"
   val sparkJobServerHost = config.getString("spark.job.server.host")
 
   // Parameters for TestSimple & Training Methods


### PR DESCRIPTION
Use one context for multiple generative plugins.
Also changed package name for kernel density and multivariate guassian models. 

They was having the same class path which did not allow us to use the same one spark context.
So, changed package path.

Also, added some readme for spark job server